### PR TITLE
syntax error clean up: remove trailing closing bracket

### DIFF
--- a/corq.js
+++ b/corq.js
@@ -49,7 +49,6 @@
 			Q = data;
 			$debug('Corq: Data loaded');
 			$debug(Q);
-			}
 		});
 		return this;
 	};


### PR DESCRIPTION
node.js won't register this module with syntax error
